### PR TITLE
Fix big menu hyperlinks

### DIFF
--- a/docs/js/oakland.js
+++ b/docs/js/oakland.js
@@ -245,6 +245,7 @@
 
 	$bigMenuItem.on('click', function(e) {
 		e.preventDefault();
+		$(".big-menu .menu-item .big-menu-group a").click(function(e) { e.stopImmediatePropagation(); });
 		$(this).toggleClass('selected').children('.big-menu-group').slideToggle('fast');
 	});
 


### PR DESCRIPTION
Because of the jQuery click event, big-menu-group anchor tags only register a toggle action instead of navigating to the linked page. This should fix that issue.
